### PR TITLE
Better socket testing

### DIFF
--- a/de.persosim.driver.connector.test/src/de/persosim/driver/connector/NativeDriverConnectorTest.java
+++ b/de.persosim.driver.connector.test/src/de/persosim/driver/connector/NativeDriverConnectorTest.java
@@ -25,6 +25,11 @@ import de.persosim.driver.test.TestDriver;
 import de.persosim.driver.test.TestSocketSim;
 import de.persosim.simulator.utils.HexString;
 
+/**
+ * This class tests the {@link NativeDriverConnector}.
+ * @author mboonk
+ *
+ */
 public class NativeDriverConnectorTest extends ConnectorTest{
 
 	private NativeDriverConnector nativeConnector;
@@ -55,7 +60,7 @@ public class NativeDriverConnectorTest extends ConnectorTest{
 		driver.stop();
 		sim.stop();
 	}
-
+	
 	private String checkPcscTag(UnsignedInteger tag, UnsignedInteger expectedResponseCode, UnsignedInteger expectedLength) throws Exception{
 		String result = driver.sendData(new UnsignedInteger(0),
 				NativeDriverInterface.PCSC_FUNCTION_GET_CAPABILITIES,

--- a/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestApduHandler.java
+++ b/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestApduHandler.java
@@ -1,7 +1,22 @@
 package de.persosim.driver.test;
 
+
+/**
+ * This interface is used to describe the APDU handling capabilities of the
+ * {@link TestSocketSim}.
+ * 
+ * @author mboonk
+ *
+ */
 public interface TestApduHandler {
 
+	/**
+	 * This method processes a given APDU as an hexadecimal formatted string
+	 * and returns a response.
+	 * 
+	 * @param apduLine the hex string encoded APDU
+	 * @return the response-APDU, also encoded as a hex string 
+	 */
 	String processCommand(String apduLine);
 
 }

--- a/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSim.java
+++ b/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSim.java
@@ -2,22 +2,36 @@ package de.persosim.driver.test;
 
 import java.io.IOException;
 
+import de.persosim.simulator.SocketSimulator;
 
+/**
+ * This class provides a simulation of the PersoSim {@link SocketSimulator} by
+ * opening a server socket on the given port. The answering behavior is defined
+ * by setting a {@link TestApduHandler}.
+ * 
+ * @author mboonk
+ *
+ */
 public class TestSocketSim {
 	private Thread communicationThread;
 	private TestSocketSimComm communication;
 	private int port;
 	private boolean isRunning;
-	
+
 	public TestSocketSim(int port) {
 		this.port = port;
 	}
-	
-	public void start() throws IOException{
+
+	/**
+	 * Creates the server and starts listening for connections.
+	 * 
+	 * @throws IOException
+	 */
+	public void start() throws IOException {
 		communication = new TestSocketSimComm(port);
 		communicationThread = new Thread(communication);
 		communicationThread.start();
-		while (!communication.isRunning()){
+		while (!communication.isRunning()) {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {
@@ -25,23 +39,35 @@ public class TestSocketSim {
 				e.printStackTrace();
 			}
 		}
-		
+
 		isRunning = true;
 	}
-	
-	public void setHandler(TestApduHandler handler){
-		if (communication != null){
+
+	/**
+	 * Sets a new handler for APDU processing, the old handler is replaced.
+	 * 
+	 * @param handler
+	 */
+	public void setHandler(TestApduHandler handler) {
+		if (communication != null) {
 			communication.setHandler(handler);
 		} else {
-			throw new NullPointerException("The communication thread is not running, therefore no handler can be set");
+			throw new NullPointerException(
+					"The communication thread is not running, therefore no handler can be set");
 		}
 	}
-	
-	public void stop() throws IOException, InterruptedException{
-		if (isRunning){
+
+	/**
+	 * Stops the server.
+	 * 
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	public void stop() throws IOException, InterruptedException {
+		if (isRunning) {
 			communication.stop();
 			communicationThread.join();
 		}
 	}
-	
+
 }

--- a/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSimComm.java
+++ b/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSimComm.java
@@ -8,6 +8,15 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 
+/**
+ * This class is the communication part of the {@link TestSocketSim}. It
+ * controls the server socket and the communication with the client. If no
+ * {@link TestApduHandler} is set, the answer to all requests is the empty
+ * string.
+ * 
+ * @author mboonk
+ *
+ */
 public class TestSocketSimComm implements Runnable {
 
 	private ServerSocket serverSocket;
@@ -15,12 +24,12 @@ public class TestSocketSimComm implements Runnable {
 	private boolean isActive;
 	private boolean isRunning = false;
 	private Socket clientSocket;
-	
-	public TestSocketSimComm(int port) throws IOException{
+
+	public TestSocketSimComm(int port) throws IOException {
 		serverSocket = new ServerSocket(port);
 		System.out.println("Starting TestSocketSim on port: " + port);
 	}
-	
+
 	@Override
 	public void run() {
 		clientSocket = null;
@@ -28,49 +37,66 @@ public class TestSocketSimComm implements Runnable {
 		isRunning = true;
 		try {
 			clientSocket = serverSocket.accept();
-			System.out.println("New TestSocketSim connection on port: " + clientSocket.getLocalPort());
+			System.out.println("New TestSocketSim connection on port: "
+					+ clientSocket.getLocalPort());
 
-			BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+			BufferedReader in = new BufferedReader(new InputStreamReader(
+					clientSocket.getInputStream()));
 			PrintStream out = new PrintStream(clientSocket.getOutputStream());
 
 			do {
 				String apduLine = in.readLine();
-				if (apduLine == null){
+				if (apduLine == null) {
 					break;
 				}
 				System.out.println("TestSocketSim received apdu: " + apduLine);
-				if (handler != null){
-					String result = handler.processCommand(apduLine);
-					System.out.println("TestSocketSim sent response: " + result);
-					out.println(result);
+				String result = "";
+				if (handler != null) {
+					result = handler.processCommand(apduLine);
+
 				}
+				System.out.println("TestSocketSim sent response: " + result);
+				out.println(result);
+
 				out.flush();
 
 			} while (isActive);
 			clientSocket.close();
-		} catch (SocketException e){
+		} catch (SocketException e) {
 			// expected behavior if closed
-		}catch (IOException e){
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
-	public void stop() throws IOException{
+	/**
+	 * Stops the server and disconnects all clients.
+	 * 
+	 * @throws IOException
+	 */
+	public void stop() throws IOException {
 		isActive = false;
-		if (clientSocket != null){
+		if (clientSocket != null) {
 			clientSocket.close();
 		}
 		serverSocket.close();
 		isRunning = false;
 	}
 
+	/**
+	 * @return true, iff the communication loop is running
+	 */
 	public boolean isRunning() {
 		return isRunning;
 	}
 
+	/**
+	 * Sets a new handler for APDU processing.
+	 * 
+	 * @param handler
+	 */
 	public void setHandler(TestApduHandler handler) {
 		this.handler = handler;
 	}
-	
-	
+
 }

--- a/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSimTest.java
+++ b/de.persosim.driver.connector.test/src/de/persosim/driver/test/TestSocketSimTest.java
@@ -34,13 +34,18 @@ public class TestSocketSimTest extends ConnectorTest {
 		sim.stop();
 	}
 	
+	/**
+	 * Positive test using 2 arbitrary strings.
+	 * @throws UnknownHostException
+	 * @throws IOException
+	 */
 	@Test
 	public void testHandleApdu() throws UnknownHostException, IOException {
 		sim.setHandler(handler);
 		new Expectations() {
 			{
-				handler.processCommand(withEqual("TESTSTRING"));
-				result = "TESTRESULT";
+				handler.processCommand(withEqual("55667788"));
+				result = "11223344";
 			}
 		};
 		
@@ -48,13 +53,13 @@ public class TestSocketSimTest extends ConnectorTest {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
 		
-		writer.write("TESTSTRING");
+		writer.write("55667788");
 		writer.newLine();
 		writer.flush();
 		
 		String result = reader.readLine();
 		
-		assertEquals("TESTRESULT", result);
+		assertEquals("11223344", result);
 		socket.close();
 		
 	}


### PR DESCRIPTION
The previous method for testing the NativeDriverConnector class was to instantiate a partly mocked PersoSim SocketSimulator using a complete PersoSimKernel including the Personalization. To provide less coupling and hard dependencies and more consistent test results a new fake simulator has been added. It can easily be instantiated and its behavior can be defined in the test case itself.
