### PR TITLE
Added a regex that ignores all non numeric charakters from PINs

### DIFF
--- a/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
+++ b/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
@@ -59,6 +59,9 @@ public class ReaderPart implements VirtualReaderUi {
 
 	private Text txtOutput;
 	private String[] savedPins = new String[4];
+	
+	// regular Expression to remove non digits from PINS
+	private String pinRegex = "\\D";
 
 	private Button[] keysNumeric;
 	private Button[] keysControl;
@@ -378,7 +381,7 @@ public class ReaderPart implements VirtualReaderUi {
 		savedPins[number] = nodePin.get(key, defaultPin);
 		
 		// remove all non digits with a regex
-		savedPins[number] = savedPins[number].replaceAll("\\D", "");
+		savedPins[number] = savedPins[number].replaceAll(pinRegex, "");
 
 		SelectionListener selectionListener = new SelectionListener() {
 
@@ -427,7 +430,7 @@ public class ReaderPart implements VirtualReaderUi {
 			public void widgetSelected(SelectionEvent e) { 
 				try {
 					// get pin from display and remove everything else
-					String pin = txtOutput.getText().replaceAll("\\D+", "");
+					String pin = txtOutput.getText().replaceAll(pinRegex, "");
 					
 					if (pin.equals("")) { 
 						throw new IllegalArgumentException("No Pin entered. Please enter a pin before saving");

--- a/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
+++ b/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
@@ -377,8 +377,8 @@ public class ReaderPart implements VirtualReaderUi {
 		
 		savedPins[number] = nodePin.get(key, defaultPin);
 		
-		// remove letters with a regex
-		savedPins[number] = savedPins[number].replaceAll("[^-?0-9]*", "");
+		// remove all non digits with a regex
+		savedPins[number] = savedPins[number].replaceAll("\\D", "");
 
 		SelectionListener selectionListener = new SelectionListener() {
 

--- a/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
+++ b/de.persosim.driver.connector.ui/src/de/persosim/driver/connector/ui/parts/ReaderPart.java
@@ -376,6 +376,9 @@ public class ReaderPart implements VirtualReaderUi {
 		final String defaultPin = "";
 		
 		savedPins[number] = nodePin.get(key, defaultPin);
+		
+		// remove letters with a regex
+		savedPins[number] = savedPins[number].replaceAll("[^-?0-9]*", "");
 
 		SelectionListener selectionListener = new SelectionListener() {
 


### PR DESCRIPTION
When a PIN is loaded from the preferences everything which is not a number will be ignored.
This is only necessary if someone modified the preferences file manually.

Ready for review.